### PR TITLE
Delete by query: prevent ES scroll context resource exhaustion

### DIFF
--- a/src/main/java/no/nav/arbeidsgiver/kandidatsok/es/client/EsIndexerHttpService.java
+++ b/src/main/java/no/nav/arbeidsgiver/kandidatsok/es/client/EsIndexerHttpService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.CreateIndexResponse;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -196,6 +197,7 @@ public class EsIndexerHttpService implements EsIndexerService, AutoCloseable {
 
         DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(indexName);
         deleteByQueryRequest.setQuery(deleteQueryBuilder);
+        deleteByQueryRequest.setScroll(TimeValue.timeValueSeconds(20)); // prevent ES scroll context resource exhaustion during heavy reindexing
         deleteByQueryRequest.setRefresh(refreshPolicy != WriteRequest.RefreshPolicy.NONE);
 
         // TODO inspect response for failures ! If at least one failure, then fail the entire request.

--- a/src/test/java/no/nav/arbeidsgiver/kandidat/kandidatsok/testsupport/DockerComposeEnv.java
+++ b/src/test/java/no/nav/arbeidsgiver/kandidat/kandidatsok/testsupport/DockerComposeEnv.java
@@ -342,7 +342,7 @@ public final class DockerComposeEnv implements AutoCloseable {
 
     private ProcessBuilder dockerCompose(String...composeCommandAndArgs) throws Exception {
         List<String> commandArgs = new ArrayList<>();
-        commandArgs.addAll(List.of(findDockerComposeExecutableName(), "--no-ansi", "--log-level", "ERROR"));
+        commandArgs.addAll(List.of(findDockerComposeExecutableName(), "--ansi", "never"));
         commandArgs.addAll(List.of("-f", composeFileAsPath(this.configFile).toString(), "-p", dockerComposeProjectName()));
         commandArgs.addAll(Arrays.asList(composeCommandAndArgs));
         ProcessBuilder pb = new ProcessBuilder(commandArgs);


### PR DESCRIPTION
By using a 20 sec scroll timeout. 5 minute default is way too much during heavy reindexing.